### PR TITLE
fix: Telescope transparency

### DIFF
--- a/lua/eldritch/groups.lua
+++ b/lua/eldritch/groups.lua
@@ -313,7 +313,7 @@ local function setup(configs)
     TelescopePreviewBorder = { fg = colors.green },
     TelescopeSelection = { fg = colors.white, bg = colors.selection },
     TelescopeMultiSelection = { fg = colors.green, bg = colors.selection },
-    TelescopeNormal = { fg = colors.fg, bg = colors.bg },
+    TelescopeNormal = { fg = colors.fg, bg = configs.transparent and "NONE" or colors.bg },
     TelescopeMatching = { fg = colors.pink },
     TelescopePromptPrefix = { fg = colors.green },
     TelescopeResultsDiffDelete = { fg = colors.red },

--- a/lua/eldritch/theme.lua
+++ b/lua/eldritch/theme.lua
@@ -478,7 +478,7 @@ function M.setup()
     TelescopePreviewBorder = { fg = c.green },
     TelescopeSelection = { fg = c.fg, bg = c.dark5 },
     TelescopeMultiSelection = { fg = c.green, bg = c.dark5 },
-    TelescopeNormal = { fg = c.fg, bg = c.bg },
+    TelescopeNormal = { fg = c.fg, bg = options.transparent and c.none or c.bg },
     TelescopeMatching = { fg = c.pink },
     TelescopePromptPrefix = { fg = c.green },
     TelescopeResultsDiffDelete = { fg = c.red },


### PR DESCRIPTION
 Summary


Fix an issue where Telescope windows would not become transparent when the ```transparent = true``` option was enabled in the setup configuration.
  Previously, Telescope retained its own background color, forcing users to apply a manual workaround by overriding highlight groups with:
  
  ```
    on_highlights = function(hl)
        hl.TelescopeNormal = { bg = 'NONE' }
    end,
```

  The Solution

  I've updated the highlight definitions in ```lua/eldritch/groups.lua``` and ```lua/eldritch/theme.lua``` to conditionally set the background for TelescopeNormal.

   - If ```transparent = true``` is set, the background color is now set to NONE.
   - If ```transparent = false```, it retains the default theme background color.

  This change aligns with Telescope's behavior on [tokyonigth](https://github.com/folke/tokyonight.nvim) theme and other components like floats and sidebars without requiring any extra configuration from the user.

  How to Test

   1. Configure the theme with transparency enabled:
```
    require('eldritch').setup { transparent = true }
```
   2. Open any Telescope picker (e.g.,```:Telescope find_files```).
   3. The Telescope window should now have a transparent background.
